### PR TITLE
Changed regex for urls, to get complete urls with parameters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,10 +48,9 @@ const searchForRemoteImages = dir => {
     } else {
       // Read the contents of the file
       let fileData = fs.readFileSync(filePath, 'utf-8')
-
       // find all the urls
       // Regex from here: https://regexr.com/39nr7
-      let urls = fileData.match(/(http(s)?)[:\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi)
+      let urls = fileData.match(/\b(?:https?|ftp):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|]/gi)
 
       if (urls) {
         urls.forEach(url => {


### PR DESCRIPTION
I noticed that the regex didn't catch certain parameters when finding ulrs, and split them into two. 
Example:
[Old regex](https://regexr.com/7ku6m) the last url is stopped at the ","
[New regex](https://regexr.com/7ku67) check the last url, it's caught completely. 

This pull request includes the fix.
As a by product, it loses some generality, but I'm unsure if that's needed. 